### PR TITLE
Add -L linkout option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 ------
 -  Update dependency versions
 -  Add support for Python 3.10
+-  Add -L/--linkout option to append answer link
 
 2.0.19
 ------

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or
 
 ### Commands
 
-    usage: howdoi [-h] [-p POS] [-n NUM] [-a] [-l] [-c] [-x] [-C] [-j] [-v] [-e [ENGINE]]
+    usage: howdoi [-h] [-p POS] [-n NUM] [-a] [-l] [-L] [-c] [-x] [-C] [-j] [-v] [-e [ENGINE]]
     [--save] [--view] [--remove] [--empty] [QUERY ...]
 
     instant coding answers via the command line
@@ -96,6 +96,7 @@ or
       -n NUM, --num NUM     number of answers to return (default: 1)
       -a, --all             display the full text of the answer
       -l, --link            display only the answer link
+      -L, --linkout         add the answer link to the output
       -c, --color           enable colorized output
       -x, --explain         explain how answer was chosen
       -C, --clear-cache     clear the cache

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@ $ howdoi -h
 #### Howdoi Flags and Arguments
 
 ```
-usage: howdoi [-h] [-p POS] [-n NUM] [-a] [-l] [-c] [-x] [-C] [-j] [-v] [-e [ENGINE]] [--save] [--view] [--remove] [--empty] [QUERY ...]
+usage: howdoi [-h] [-p POS] [-n NUM] [-a] [-l] [-L] [-c] [-x] [-C] [-j] [-v] [-e [ENGINE]] [--save] [--view] [--remove] [--empty] [QUERY ...]
 
 instant coding answers via the command line
 
@@ -26,6 +26,7 @@ optional arguments:
   -n NUM, --num NUM     number of answers to return (default: 1)
   -a, --all             display the full text of the answer
   -l, --link            display only the answer link
+  -L, --linkout         add the answer link to the output
   -c, --color           enable colorized output
   -x, --explain         explain how answer was chosen
   -C, --clear-cache     clear the cache

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -504,6 +504,10 @@ def _format_answers(args, res):
         next_ans = answer["answer"]
         if args["link"]:  # if we only want links
             next_ans = answer["link"]
+        elif args.get("linkout") and answer.get("link"):
+            if not next_ans.endswith("\n"):
+                next_ans += "\n"
+            next_ans += answer["link"]
         formatted_answers.append(next_ans or NO_RESULTS_MESSAGE)
 
     return build_splitter().join(formatted_answers)
@@ -518,6 +522,7 @@ def _get_help_instructions():
         '>>> howdoi {} -a (read entire answer)',
         '>>> howdoi {} -n [number] (retrieve n number of answers)',
         '>>> howdoi {} -l (display only a link to where the answer is from',
+        '>>> howdoi {} -L (add the answer link to the output)',
         '>>> howdoi {} -c (Add colors to the output)',
         '>>> howdoi {} -e (Specify the search engine you want to use e.g google,bing)'
     ]
@@ -670,6 +675,7 @@ def get_parser():
     parser.add_argument('--num-answers', help=argparse.SUPPRESS)
     parser.add_argument('-a', '--all', help='display the full text of the answer', action='store_true')
     parser.add_argument('-l', '--link', help='display only the answer link', action='store_true')
+    parser.add_argument('-L', '--linkout', help='add answer link to the output', action='store_true')
     parser.add_argument('-c', '--color', help='enable colorized output', action='store_true')
     parser.add_argument('-x', '--explain', help='explain how answer was chosen', action='store_true')
     parser.add_argument('-C', '--clear-cache', help='clear the cache',

--- a/tests/test_linkout.py
+++ b/tests/test_linkout.py
@@ -1,0 +1,25 @@
+import re
+import unittest
+from unittest.mock import patch
+from cachelib import NullCache
+
+from howdoi import howdoi
+from test_howdoi import _get_result_mock
+
+class LinkoutTestCase(unittest.TestCase):
+    def setUp(self):
+        self.patcher_get_result = patch.object(howdoi, '_get_result')
+        self.mock_get_result = self.patcher_get_result.start()
+        self.mock_get_result.side_effect = _get_result_mock
+        howdoi.cache = NullCache()
+        self.query = 'print hello world in python'
+
+    def tearDown(self):
+        self.patcher_get_result.stop()
+
+    def test_linkout_appends_url(self):
+        result = howdoi.howdoi(self.query + ' -L')
+        self.assertRegex(result, r'http.?://.*questions/\d')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `-L/--linkout` argument to append source URL
- include linkout examples in help text and docs
- document new flag in README and CHANGES
- test that linkout appends a link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68444e170138832698cfcf2dded99daa